### PR TITLE
use pathlib instead of os.paht.

### DIFF
--- a/src/annotation_tool/application.py
+++ b/src/annotation_tool/application.py
@@ -43,7 +43,6 @@ class Application(QApplication):
         self.installTranslator(translator)
 
         main_window = MainWindow()
-        print(get_settings_file())
         main_window.load_settings(get_settings_file())
         main_window.actionAboutQT.triggered.connect(self.aboutQt)
 

--- a/src/annotation_tool/application.py
+++ b/src/annotation_tool/application.py
@@ -13,8 +13,12 @@ from .project import Project
 
 def get_data_dir():
     """Returns the directory where application data is stored."""
-    return Path(QStandardPaths.standardLocations(
+    data_dir = Path(QStandardPaths.standardLocations(
         QStandardPaths.AppDataLocation)[0]).joinpath("annotation_tool")
+    if not data_dir.exists():
+        data_dir.mkdir(parents=True)
+    return data_dir
+
 
 def get_settings_file():
     """

--- a/src/annotation_tool/application.py
+++ b/src/annotation_tool/application.py
@@ -3,7 +3,8 @@ The application that handles the initial program state and initialization of
 the GUI.
 """
 
-import os, sys
+import sys
+from pathlib import Path
 from PySide6.QtCore import QCommandLineParser, QLocale, QStandardPaths, QTranslator
 from PySide6.QtGui import QScreen
 from PySide6.QtWidgets import QApplication
@@ -12,15 +13,15 @@ from .project import Project
 
 def get_data_dir():
     """Returns the directory where application data is stored."""
-    return os.path.join(os.path.dirname(QStandardPaths.standardLocations(
-        QStandardPaths.AppDataLocation)[0]), "annotation_tool")
+    return Path(QStandardPaths.standardLocations(
+        QStandardPaths.AppDataLocation)[0]).joinpath("annotation_tool")
 
 def get_settings_file():
     """
     Returns the json file which stores a list of recently used projects and the
     shortcuts.
     """
-    return os.path.join(get_data_dir(), "settings.json")
+    return get_data_dir().joinpath("settings.json")
 
 class Application(QApplication):
     def __init__(self, args) -> None:
@@ -38,6 +39,7 @@ class Application(QApplication):
         self.installTranslator(translator)
 
         main_window = MainWindow()
+        print(get_settings_file())
         main_window.load_settings(get_settings_file())
         main_window.actionAboutQT.triggered.connect(self.aboutQt)
 


### PR DESCRIPTION
Hey,

There seems to be another issue with paths between Windows and UNIX. I propose to use pathlib instead of os.path. This seems to relex some Issues here.

Best,

Andreas