### PR TITLE
Move exception hook to the application

### DIFF
--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -97,13 +97,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 "shortcuts": self.shortcuts,
             }, file)
 
-    def excepthook(self, exc_type, exc_value, exc_tb):
-        error_dialog = QErrorMessage(self)
-        message = "\n".join(traceback.format_exception(exc_type,
-                exc_value, exc_tb))
-        print(message)
-        error_dialog.showMessage(message, "exception")
-
     @Slot()
     def project_opened(self, project):
         self.recent_projects.append(project.project_file)


### PR DESCRIPTION
Also only show one error dialog at a time, preventing many dialogs to spawn when an error occurs multiple times.