### PR TITLE
Load dictionary and array representation of project annotations

### DIFF
--- a/src/test/test_opened_project.py
+++ b/src/test/test_opened_project.py
@@ -5,7 +5,7 @@ from voice_annotation_tool.project import Project, Annotation
 
 annotation_data = {
     "client_id": "id",
-    "path": "",
+    "path": "path",
     "text": "",
     "up_votes": 0,
     "down_votes": 0,
@@ -19,7 +19,8 @@ annotation_data = {
 def project_frame():
     frame = OpenedProjectFrame()
     project = Project("")
-    project.annotations = [Annotation(annotation_data)] * 3
+    for annotation in range(3):
+        project.add_annotation(Annotation(annotation_data))
     frame.load_project(project)
     return frame
 

--- a/src/test/test_opened_project.py
+++ b/src/test/test_opened_project.py
@@ -5,7 +5,7 @@ from voice_annotation_tool.project import Project, Annotation
 
 annotation_data = {
     "client_id": "id",
-    "path": "path",
+    "path": "",
     "text": "",
     "up_votes": 0,
     "down_votes": 0,
@@ -19,7 +19,8 @@ annotation_data = {
 def project_frame():
     frame = OpenedProjectFrame()
     project = Project("")
-    for annotation in range(3):
+    for annotation_num in range(3):
+        annotation_data["path"] = "path_" + str(annotation_num)
         project.add_annotation(Annotation(annotation_data))
     frame.load_project(project)
     return frame

--- a/src/test/test_project.py
+++ b/src/test/test_project.py
@@ -1,5 +1,4 @@
 from io import StringIO
-import os
 
 import pytest
 from voice_annotation_tool.project import Annotation
@@ -8,7 +7,7 @@ from voice_annotation_tool.project import Project
 @pytest.fixture
 def project():
     project = Project("")
-    project.annotations.append(Annotation({"path": "path", "sentence": "text"}))
+    project.add_annotation(Annotation({"path": "path", "sentence": "text"}))
     return project
 
 def test_creation(project):

--- a/src/voice_annotation_tool/annotation_list_model.py
+++ b/src/voice_annotation_tool/annotation_list_model.py
@@ -30,5 +30,12 @@ class AnnotationListModel(QAbstractListModel):
             return annotation
         return None
 
+    def removeRow(self, row: int, parent=QModelIndex()) -> bool:
+        if not self._data or row < 0 or row >= self.rowCount():
+            return False
+        self._data.annotations.remove(row)
+        return True
+
     def index(self, row: int, column: int = 0, parent=QModelIndex()) -> QModelIndex:
         return self.createIndex(row, column)
+

--- a/src/voice_annotation_tool/annotation_list_model.py
+++ b/src/voice_annotation_tool/annotation_list_model.py
@@ -30,12 +30,5 @@ class AnnotationListModel(QAbstractListModel):
             return annotation
         return None
 
-    def removeRow(self, row: int, parent=QModelIndex()) -> bool:
-        if not self._data or row < 0 or row >= self.rowCount():
-            return False
-        self._data.annotations.remove(row)
-        return True
-
     def index(self, row: int, column: int = 0, parent=QModelIndex()) -> QModelIndex:
         return self.createIndex(row, column)
-

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -6,7 +6,7 @@ edit the annotation.
 """
 
 import os
-from typing import Dict, List, Union
+from typing import Dict, List
 from PySide6.QtGui import QIcon
 from PySide6.QtCore import QModelIndex, QSize, Slot, QTime, QUrl
 from PySide6.QtMultimedia import QMediaPlayer, QAudioOutput, QAudioDecoder
@@ -185,8 +185,8 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
 
     def delete_selected(self):
         """Delete the selected annotations and audio files."""
-        for selected in self.get_selected_annotations()[::-1]:
-            self.project.delete_annotation(selected.row())
+        for selected in self.get_selected_annotations():
+            self.project.delete_annotation(selected)
         self.annotationList.model().layoutChanged.emit()
 
     def get_selected_annotations(self) -> List[Annotation]:
@@ -246,7 +246,9 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
     @Slot()
     def text_changed(self):
         text = self.annotationEdit.toPlainText()
-        self.project.annotate(self.annotationList.currentIndex().row(), text)
+        selected_annotation: Annotation = self.annotationList.currentIndex()\
+                .data(ANNOTATION_ROLE)
+        self.project.annotate(selected_annotation, text)
         self.annotationList.model().layoutChanged.emit()
 
     @Slot()

--- a/src/voice_annotation_tool/project.py
+++ b/src/voice_annotation_tool/project.py
@@ -5,7 +5,6 @@ Handles loading and saving projects as well as loading the samples from the
 audio folder.
 """
 
-from itertools import islice
 from io import StringIO
 import os, csv
 from pathlib import Path


### PR DESCRIPTION
A dictionary that makes it possible to access annotations by their file names is now stored alongside the array of annotations. This does not slow down the program as the dictionary was created before, but only temporarily.
To make sure both data structures are kept in sync, the `add_annotation` function was added. Some Project methods now take an annotation object instead of an index.