### PR TITLE
Fix error when pressing mark unchanged twice

### DIFF
--- a/src/voice_annotation_tool/project.py
+++ b/src/voice_annotation_tool/project.py
@@ -64,7 +64,8 @@ class Project:
 
     def mark_unchanged(self, annotation : Annotation) -> None:
         annotation.modified = False
-        self.modified_annotations.remove(annotation.path)
+        if annotation.path in self.modified_annotations:
+            self.modified_annotations.remove(annotation.path)
 
     def save(self):
         """

--- a/test/test_opened_project.py
+++ b/test/test_opened_project.py
@@ -38,3 +38,8 @@ def test_metadata_header_filled_on_open(project_frame):
 def test_tooltips_have_shortcuts(project_frame):
     play_button : QPushButton = project_frame.playPauseButton
     assert play_button.shortcut().toString() in play_button.toolTip()
+
+def test_mark_unchanged(project_frame: OpenedProjectFrame):
+    project_frame.mark_unchanged_pressed()
+    project_frame.mark_unchanged_pressed()
+    assert not project_frame.project.annotations[0].modified


### PR DESCRIPTION
The project didn't check if the annotations where in the modified annotations list.