### PR TITLE
Show warning when closing a project with unsaved changes 

### DIFF
--- a/src/voice_annotation_tool/annotation.py
+++ b/src/voice_annotation_tool/annotation.py
@@ -57,3 +57,6 @@ class Annotation:
         self.accent = dict.get("accent")
         self.down_votes = int(dict.get("down_votes", 0))
         self.up_votes = int(dict.get("up_votes", 0))
+
+    def __hash__(self):
+        return hash(frozenset(self.to_dict().items()))

--- a/src/voice_annotation_tool/project.py
+++ b/src/voice_annotation_tool/project.py
@@ -141,3 +141,6 @@ class Project:
         for annotation in self.annotations:
             data.append({annotation.path.name: annotation.sentence})
         json.dump(data, outfile)
+
+    def __hash__(self):
+        return hash(frozenset(map(hash, self.annotations)))


### PR DESCRIPTION
A dialog with options to discard and save the changes is shown when closing a project with unsaved changes. If a project has changed is determined by comparing its hash.
Depends on #48 