### PR TITLE
Cleaner exit when project file doesn't exists

### DIFF
--- a/src/voice_annotation_tool/application.py
+++ b/src/voice_annotation_tool/application.py
@@ -49,7 +49,11 @@ class Application(QApplication):
 
         args = parser.positionalArguments()
         if len(args) > 0:
-            self.main_window.load_project_from_file(Path(args[0]))
+            path = Path(args[0])
+            if not path.is_file():
+                print("Project file not found.")
+                exit(2) # No such file or directory.
+            self.main_window.load_project_from_file(path)
 
         self.main_window.show()
 


### PR DESCRIPTION
Fixes #51

In the future passing a nonexisting project path could also open it.