### PR TITLE
Fix duplicated annotations when loading audio files or TSV files

### DIFF
--- a/src/voice_annotation_tool/project.py
+++ b/src/voice_annotation_tool/project.py
@@ -43,11 +43,11 @@ class Project:
             return
         for audio_file in os.listdir(self.audio_folder):
             path = Path(audio_file)
-            if path.suffix in [".mp3", ".ogg", ".mp4", ".webm", ".avi", ".mkv", ".wav"]:
-                if not audio_file in self.annotations_by_path:
-                    annotation = Annotation()
-                    annotation.path = self.audio_folder.joinpath(path)
-                    self.add_annotation(annotation)
+            if not path.suffix in [".mp3", ".ogg", ".mp4", ".webm", ".avi", ".mkv", ".wav"]:
+                continue
+            annotation = Annotation()
+            annotation.path = self.audio_folder.joinpath(path)
+            self.add_annotation(annotation)
 
     def annotate(self, annotation: Annotation, text: str) -> None:
         """Changes the text of the given annotation."""
@@ -110,10 +110,18 @@ class Project:
         self.annotations.remove(annotation)
 
     def add_annotation(self, annotation: Annotation):
+        """Adds the annotation to the project. If an annotation with
+        the same path already exists it is replaced. If the audio
+        folder is specified, it is added to the annotation path.
+        """
         if self.audio_folder:
             annotation.path = self.audio_folder.joinpath(annotation.path)
+        if annotation.path.name in self.annotations_by_path:
+            existing = self.annotations.index(self.annotations_by_path[annotation.path.name])
+            self.annotations[existing] = annotation
+        else:
+            self.annotations.append(annotation)
         self.annotations_by_path[annotation.path.name] = annotation
-        self.annotations.append(annotation)
 
     def importCSV(self, infile: StringIO):
         reader = csv.reader(infile, delimiter=";")

--- a/src/voice_annotation_tool/project.py
+++ b/src/voice_annotation_tool/project.py
@@ -95,7 +95,7 @@ class Project:
             annotation = Annotation(row)
             if annotation.path.name in self.modified_annotations:
                 annotation.modified = True
-            self.add_annotation(annotation)
+            self.add_annotation(annotation, overwrite=True)
         print("loaded csv")
 
     def delete_tsv(self):
@@ -109,16 +109,19 @@ class Project:
         self.annotations_by_path.pop(annotation.path.name)
         self.annotations.remove(annotation)
 
-    def add_annotation(self, annotation: Annotation):
+    def add_annotation(self, annotation: Annotation, overwrite=False):
         """Adds the annotation to the project. If an annotation with
-        the same path already exists it is replaced. If the audio
-        folder is specified, it is added to the annotation path.
+        the same path already exists and overwrite is true it is replaced.
+        If the audio folder is specified, it is added to the annotation path.
         """
         if self.audio_folder:
             annotation.path = self.audio_folder.joinpath(annotation.path)
         if annotation.path.name in self.annotations_by_path:
-            existing = self.annotations.index(self.annotations_by_path[annotation.path.name])
-            self.annotations[existing] = annotation
+            if overwrite:
+                existing = self.annotations.index(self.annotations_by_path[annotation.path.name])
+                self.annotations[existing] = annotation
+            else:
+                return
         else:
             self.annotations.append(annotation)
         self.annotations_by_path[annotation.path.name] = annotation

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -85,3 +85,23 @@ abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent"""
     assert annotation.down_votes == 2
     assert annotation.gender == "other"
     assert annotation.path == Path("tmp/audio/sample.mp3")
+
+
+def test_no_duplicates_when_loading_files(tmpdir):
+    audio_dir = Path(tmpdir)
+    for file_num in range(5):
+        audio_dir.joinpath(str(file_num) + ".mp3").touch()
+    project = Project()
+    project.load_audio_files(audio_dir)
+    project.load_audio_files(audio_dir)
+    assert len(project.annotations) == 5
+
+
+def test_no_duplicates_when_loading_tsv():
+    project = Project()
+    content = """client_id\tpath\tsentence\tup_votes\tdown_votes\tage\tgender\taccent
+abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent
+abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent
+abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent"""
+    project.load_tsv_file(StringIO(content))
+    assert len(project.annotations) == 1

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -105,3 +105,15 @@ abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent
 abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent"""
     project.load_tsv_file(StringIO(content))
     assert len(project.annotations) == 1
+
+
+def test_duplicates_get_overwritten():
+    project = Project()
+    annotation = Annotation()
+    annotation.path = Path("sample.mp3")
+    project.add_annotation(annotation)
+    project.add_annotation(annotation)
+    content = """client_id\tpath\tsentence\tup_votes\tdown_votes\tage\tgender\taccent
+abc\tsample.mp3\ttext\t2\t2\ttwenties\tother\taccent"""
+    project.load_tsv_file(StringIO(content))
+    assert len(project.annotations) == 1


### PR DESCRIPTION
The correct behavior is that annotations loaded from the TSV file which already exist are overwritten.
Fixes #50 