### PR TITLE
Add Github action that publishes to PyPi and TestPyPi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish Python distributions to PyPI
+name: Publish Python distributions to PyPI and TestPyPI
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-publish:
-    name: Build and publish Python distributions to PyPI
+    name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
@@ -19,6 +19,12 @@ jobs:
       run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,10 +1,10 @@
-name: Publish Python distributions to PyPI and TestPyPI
+name: Publish Python distributions to PyPI
 
 on: push
 
 jobs:
   build-and-publish:
-    name: Build and publish Python distributions to PyPI and TestPyPI
+    name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
@@ -18,13 +18,8 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m build --sdist --wheel --outdir dist/ .
-    - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
     - name: Publish tagged commits to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish Python distributions to PyPI
 
-on: push
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-and-publish:
@@ -13,13 +16,10 @@ jobs:
       with:
         python-version: 3.9
     - name: Install pypa/build
-      run: >-
-        python -m pip install build --user
+      run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m build --sdist --wheel --outdir dist/ .
-    - name: Publish tagged commits to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      run: python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,30 @@
+name: Publish Python distributions to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distributions to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish tagged commits to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = voice-annotation-tool
-version = 1.8.0
+version = 1.7.0
 author = Feliks Weber
 author_email = feliks.weber@tu-dresden.de
 description = Utility to annotate short voice samples

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = voice-annotation-tool
-version = 1.8.1
+version = 1.8.0
 author = Feliks Weber
 author_email = feliks.weber@tu-dresden.de
 description = Utility to annotate short voice samples

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = voice-annotation-tool
-version = 1.7.0
+version = 1.8.0
 author = Feliks Weber
 author_email = feliks.weber@tu-dresden.de
 description = Utility to annotate short voice samples

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = voice-annotation-tool
-version = 1.8.0
+version = 1.8.1
 author = Feliks Weber
 author_email = feliks.weber@tu-dresden.de
 description = Utility to annotate short voice samples


### PR DESCRIPTION
By default distributions are published to TestPyPi, only commits that are tagged are published to PyPi.
This PR doesn't create a PyPi version, that can be done after it is merged by creating a release.

The test PyPi page can be found here: https://test.pypi.org/project/voice-annotation-tool/