### PR TITLE
Disable playback buttons instead of showing an error when audio file doesn't exist

### DIFF
--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -138,9 +138,9 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
             self.selection_changed
         )
         self.annotationEdit.clear()
+        self.update_metadata_widgets()
         if len(project.annotations):
             self.annotationList.setCurrentIndex(self.annotationList.model().index(0, 0))
-        self.update_metadata_widgets()
 
     def update_metadata_widgets(self):
         """Disables or enables the widgets used to edit the annotation
@@ -248,7 +248,10 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         self.annotationEdit.blockSignals(True)
         self.annotationEdit.setText(annotation.sentence)
         self.annotationEdit.blockSignals(False)
-        self.audioPlaybackWidget.load_file(annotation.path)
+        if annotation.path.is_file():
+            self.audioPlaybackWidget.load_file(annotation.path)
+        for buttons in self.get_playback_buttons():
+            buttons.setEnabled(annotation.path.is_file())
 
     @Slot()
     def import_profile_pressed(self):


### PR DESCRIPTION
Previously when selecting a file which didn't exist two errors where shown. Now only the playback buttons are disabled, as there is no audio to play.
Fixes #59