### PR TITLE
Refine shortcut settings dialog

### DIFF
--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -5,4 +5,6 @@ Keyboard Shortcuts
 
 Keyboard shortcuts can be configured under ``Settings > Keyboard Shortcuts.``
 
-Examples of possible shortcuts are ``Ctrl+L``, ``Alt+2``, ``Esc``, ``Ctrl+Shift+Enter``, ``Ctrl+Right``.
+To change a shortcut, click the button and press the shortcut you want to assign.
+
+Right-click the button to clear the shortcut.

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -30,7 +30,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         self.project_settings_dialog = ProjectSettingsDialog()
         self.project_settings_dialog.settings_confirmed.connect(self.settings_confirmed)
-        self.shortcut_settings_dialog = ShortcutSettingsDialog()
         self.opened_project_frame = OpenedProjectFrame()
         self.choose_project_frame = ChooseProjectFrame()
 
@@ -66,9 +65,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.opened_project_frame.hide()
 
         # Connections
-        self.shortcut_settings_dialog.shortcuts_confirmed.connect(
-            self.shortcuts_confirmed
-        )
         self.choose_project_frame.project_opened.connect(self.recent_project_chosen)
         self.choose_project_frame.create_project_pressed.connect(self.new_project)
         self.actionNewProject.triggered.connect(self.new_project)
@@ -123,11 +119,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.choose_project_frame.load_recent_projects(self.recent_projects)
 
         self.opened_project_frame.apply_shortcuts(data.get("shortcuts", []))
-        self.shortcut_settings_dialog.load_buttons(
-            self.opened_project_frame.get_playback_buttons()
-        )
-        self.shortcut_settings_dialog.load_existing(self.menuEdit)
-        self.shortcut_settings_dialog.load_existing(self.menuFile)
 
     def save_settings(self, to: TextIO):
         """
@@ -386,7 +377,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     @Slot()
     def configure_shortcuts(self):
-        self.shortcut_settings_dialog.exec()
+        shortcut_settings_dialog = ShortcutSettingsDialog()
+        shortcut_settings_dialog.load_buttons(
+            self.opened_project_frame.get_playback_buttons()
+        )
+        shortcut_settings_dialog.load_existing(self.menuEdit)
+        shortcut_settings_dialog.load_existing(self.menuFile)
+        shortcut_settings_dialog.shortcuts_confirmed.connect(
+            self.shortcuts_confirmed
+        )
+        shortcut_settings_dialog.exec()
 
     @Slot()
     def shortcuts_confirmed(self, shortcuts):

--- a/src/voice_annotation_tool/shortcut_settings_dialog.py
+++ b/src/voice_annotation_tool/shortcut_settings_dialog.py
@@ -50,7 +50,7 @@ class ShortcutSettingsDialog(QDialog, Ui_ShortcutSettingsDialog):
         for widget in self.shortcut_widgets:
             shortcut = widget.get_shortcut()
             shortcuts.append(shortcut)
-            if shortcut in self.existing:
+            if not shortcut.isEmpty() and shortcut in self.existing:
                 error = QErrorMessage(self)
                 message = self.tr(
                     "{shortcut} is already used elsewhere in the application."

--- a/src/voice_annotation_tool/shortcut_settings_dialog.py
+++ b/src/voice_annotation_tool/shortcut_settings_dialog.py
@@ -1,11 +1,8 @@
 from typing import List
 from PySide6.QtCore import Slot, Signal
+from PySide6.QtGui import QKeySequence
 from PySide6.QtWidgets import (
     QDialog,
-    QHBoxLayout,
-    QLineEdit,
-    QLabel,
-    QSizePolicy,
     QPushButton,
     QErrorMessage,
     QWidget,
@@ -41,13 +38,15 @@ class ShortcutSettingsDialog(QDialog, Ui_ShortcutSettingsDialog):
             if not isinstance(button, QPushButton):
                 continue
             shortcut = button.shortcut().toString()
-            shortcut_widget = ShortcutWidget(button.toolTip().replace(shortcut, ""))
+            shortcut_widget = ShortcutWidget(
+                button.toolTip().replace(shortcut, ""), button.shortcut()
+            )
             self.shortcut_widgets.append(shortcut_widget)
             self.settings.addWidget(shortcut_widget)
 
     @Slot()
     def accept(self):
-        shortcuts: List[str] = []
+        shortcuts: List[QKeySequence] = []
         for widget in self.shortcut_widgets:
             shortcut = widget.get_shortcut()
             shortcuts.append(shortcut)

--- a/src/voice_annotation_tool/shortcut_settings_dialog.py
+++ b/src/voice_annotation_tool/shortcut_settings_dialog.py
@@ -1,4 +1,3 @@
-from typing import List
 from PySide6.QtCore import Slot, Signal
 from PySide6.QtGui import QKeySequence
 from PySide6.QtWidgets import (
@@ -21,8 +20,8 @@ class ShortcutSettingsDialog(QDialog, Ui_ShortcutSettingsDialog):
     def __init__(self):
         super().__init__()
         self.setupUi(self)
-        self.shortcut_widgets: List[ShortcutWidget] = []
-        self.existing: List[str] = []
+        self.shortcut_widgets: list[ShortcutWidget] = []
+        self.existing: list[str] = []
 
     def load_existing(self, widget: QWidget):
         """Loads the shortcuts used by the given widget into a list.
@@ -32,7 +31,7 @@ class ShortcutSettingsDialog(QDialog, Ui_ShortcutSettingsDialog):
         for action in widget.actions():
             self.existing.append(action.shortcut().toString())
 
-    def load_buttons(self, buttons: List[QPushButton]):
+    def load_buttons(self, buttons: list[QPushButton]):
         """Generates widgets which can be used to edit the shortcuts."""
         for button in buttons:
             if not isinstance(button, QPushButton):
@@ -46,7 +45,7 @@ class ShortcutSettingsDialog(QDialog, Ui_ShortcutSettingsDialog):
 
     @Slot()
     def accept(self):
-        shortcuts: List[QKeySequence] = []
+        shortcuts: list[QKeySequence] = []
         for widget in self.shortcut_widgets:
             shortcut = widget.get_shortcut()
             shortcuts.append(shortcut)

--- a/src/voice_annotation_tool/shortcut_widget.py
+++ b/src/voice_annotation_tool/shortcut_widget.py
@@ -1,0 +1,14 @@
+from PySide6.QtWidgets import QFrame
+
+from voice_annotation_tool.shortcut_widget_ui import Ui_ShortcutWidget
+
+
+class ShortcutWidget(QFrame, Ui_ShortcutWidget):
+    def __init__(self, name: str):
+        super().__init__()
+        self.setupUi(self)
+        self.name = name
+        "The description of the shortcut."
+
+    def get_shortcut(self) -> str:
+        return ""

--- a/src/voice_annotation_tool/shortcut_widget.py
+++ b/src/voice_annotation_tool/shortcut_widget.py
@@ -1,4 +1,4 @@
-from PySide6.QtGui import QKeyEvent, QKeySequence
+from PySide6.QtGui import QKeyEvent, QKeySequence, QMouseEvent
 from PySide6.QtWidgets import QFrame
 from PySide6.QtCore import Qt
 
@@ -35,6 +35,11 @@ class ShortcutWidget(QFrame, Ui_ShortcutWidget):
 
     def _update_button_text(self):
         self.pushButton.setText(self.shortcut.toString())
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.RightButton:
+            self.shortcut = QKeySequence()
+            self._update_button_text()
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         key = event.key()

--- a/src/voice_annotation_tool/shortcut_widget.py
+++ b/src/voice_annotation_tool/shortcut_widget.py
@@ -19,6 +19,8 @@ MODIFIER_KEYS = {
 }
 
 class ShortcutWidget(QFrame, Ui_ShortcutWidget):
+    """Widget used to record a shortcut."""
+
     def __init__(self, name: str, shortcut: QKeySequence):
         super().__init__()
         self.setupUi(self)
@@ -33,7 +35,7 @@ class ShortcutWidget(QFrame, Ui_ShortcutWidget):
         """Returns the currently set shortcut."""
         return self.shortcut
 
-    def _update_button_text(self):
+    def _update_button_text(self) -> None:
         self.pushButton.setText(self.shortcut.toString())
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
@@ -43,7 +45,7 @@ class ShortcutWidget(QFrame, Ui_ShortcutWidget):
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         key = event.key()
-        if key in MODIFIER_KEYS:
+        if key in MODIFIER_KEYS or key == Qt.Key_unknown:
             return
         for modifier in MODIFIERS:
             if event.modifiers() & modifier:

--- a/src/voice_annotation_tool/shortcut_widget.py
+++ b/src/voice_annotation_tool/shortcut_widget.py
@@ -18,6 +18,7 @@ MODIFIER_KEYS = {
     Qt.Key_Meta,
 }
 
+
 class ShortcutWidget(QFrame, Ui_ShortcutWidget):
     """Widget used to record a shortcut."""
 

--- a/src/voice_annotation_tool/shortcut_widget.py
+++ b/src/voice_annotation_tool/shortcut_widget.py
@@ -4,6 +4,19 @@ from PySide6.QtCore import Qt
 
 from voice_annotation_tool.shortcut_widget_ui import Ui_ShortcutWidget
 
+MODIFIERS = {
+    Qt.ShiftModifier,
+    Qt.ControlModifier,
+    Qt.AltModifier,
+    Qt.MetaModifier,
+}
+
+MODIFIER_KEYS = {
+    Qt.Key_Shift,
+    Qt.Key_Control,
+    Qt.Key_Alt,
+    Qt.Key_Meta,
+}
 
 class ShortcutWidget(QFrame, Ui_ShortcutWidget):
     def __init__(self, name: str, shortcut: QKeySequence):
@@ -25,12 +38,9 @@ class ShortcutWidget(QFrame, Ui_ShortcutWidget):
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         key = event.key()
-        for modifier in [
-            Qt.ShiftModifier,
-            Qt.ControlModifier,
-            Qt.AltModifier,
-            Qt.MetaModifier,
-        ]:
+        if key in MODIFIER_KEYS:
+            return
+        for modifier in MODIFIERS:
             if event.modifiers() & modifier:
                 key += modifier
         self.shortcut = QKeySequence(key)

--- a/src/voice_annotation_tool/shortcut_widget.py
+++ b/src/voice_annotation_tool/shortcut_widget.py
@@ -1,14 +1,37 @@
+from PySide6.QtGui import QKeyEvent, QKeySequence
 from PySide6.QtWidgets import QFrame
+from PySide6.QtCore import Qt
 
 from voice_annotation_tool.shortcut_widget_ui import Ui_ShortcutWidget
 
 
 class ShortcutWidget(QFrame, Ui_ShortcutWidget):
-    def __init__(self, name: str):
+    def __init__(self, name: str, shortcut: QKeySequence):
         super().__init__()
         self.setupUi(self)
+        self.label.setText(name)
         self.name = name
         "The description of the shortcut."
+        self.shortcut = shortcut
+        "The last set shortcut."
+        self._update_button_text()
 
-    def get_shortcut(self) -> str:
-        return ""
+    def get_shortcut(self) -> QKeySequence:
+        """Returns the currently set shortcut."""
+        return self.shortcut
+
+    def _update_button_text(self):
+        self.pushButton.setText(self.shortcut.toString())
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        key = event.key()
+        for modifier in [
+            Qt.ShiftModifier,
+            Qt.ControlModifier,
+            Qt.AltModifier,
+            Qt.MetaModifier,
+        ]:
+            if event.modifiers() & modifier:
+                key += modifier
+        self.shortcut = QKeySequence(key)
+        self._update_button_text()

--- a/ui/shortcut_widget.ui
+++ b/ui/shortcut_widget.ui
@@ -38,6 +38,9 @@
    </item>
    <item>
     <widget class="QPushButton" name="pushButton">
+     <property name="toolTip">
+      <string>Click and press any key to change the shortcut. Right click to reset.</string>
+     </property>
      <property name="text">
       <string/>
      </property>

--- a/ui/shortcut_widget.ui
+++ b/ui/shortcut_widget.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShortcutWidget</class>
+ <widget class="QWidget" name="ShortcutWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>175</width>
+    <height>39</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Instead of writing the shortcut into a text field, each shortcut has a button that can be clicked to record a shortcut.

Preview:

![image](https://user-images.githubusercontent.com/98736859/173544883-c1895526-6ce9-4f89-9e2a-3155ec4684d8.png)

Fixes #60 and #31 