### PR TITLE
Add option to automatically annotate samples using Coqui

### DIFF
--- a/docs/generate_annotations.rst
+++ b/docs/generate_annotations.rst
@@ -1,14 +1,14 @@
 Automatic Annotation Generation
 ===============================
 
-To speed up annotation Coqui's speech-to-text capabilities can be used to automatically generate annotations for the samples.
+To speed up annotation, Coqui's speech-to-text capabilities can be used to automatically generate annotations for the samples.
 
 Install FFmpeg
 --------------
 
 If you don't have it already, install FFmpeg on your machine. It is required to prepare the audio files so that they can be used by Coqui.
 
-**Windows: Use Chocolatey or download from here**
+**Windows: Use Chocolatey or download it from `here <https://www.ffmpeg.org/download.html>`_**
 
 **Linux: Use your package manager of choice.**
 
@@ -17,7 +17,7 @@ Download a Language Model
 
 If you don't want to train your own model, you can download a pre-trained one from the official Coqui website: https://coqui.ai/models.
 
-Usage
------
+Generate Annotations
+--------------------
 
 First, select your language model under `Edit>Select Language Model...`. Then choose `Edit>Auto-Generate Annotation Text` and wait for the process to complete. A popup will be shown once the it is finished.

--- a/docs/generate_annotations.rst
+++ b/docs/generate_annotations.rst
@@ -1,0 +1,23 @@
+Automatic Annotation Generation
+===============================
+
+To speed up annotation Coqui's speech-to-text capabilities can be used to automatically generate annotations for the samples.
+
+Install FFmpeg
+--------------
+
+If you don't have it already, install FFmpeg on your machine. It is required to prepare the audio files so that they can be used by Coqui.
+
+**Windows: Use Chocolatey or download from here**
+
+**Linux: Use your package manager of choice.**
+
+Download a Language Model
+-------------------------
+
+If you don't want to train your own model, you can download a pre-trained one from the official Coqui website: https://coqui.ai/models.
+
+Usage
+-----
+
+First, select your language model under `Edit>Select Language Model...`. Then choose `Edit>Auto-Generate Annotation Text` and wait for the process to complete. A popup will be shown once the it is finished.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,3 +14,4 @@ Contents
    tsv_format
    import_export
    api
+   generate_annotations

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
 	PySide6 >=6.2.2.1
 	shiboken6 >=6.2.2.1	
 	stt >=1.3.0
+	ffmpeg-python >=0.2.0
 
 [options.entry_points]
 console_scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ include_package_data = True
 install_requires =
 	PySide6 >=6.2.2.1
 	shiboken6 >=6.2.2.1	
+	stt >=1.3.0
 
 [options.entry_points]
 console_scripts = 

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -435,13 +435,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 ),
             )
         model = Model(str(self.language_model))
+        tmp_dir = Path(QStandardPaths.writableLocation(QStandardPaths.TempLocation))
         for annotation in self.project.annotations:
             if annotation.sentence or not annotation.path.is_file():
                 continue
-            temp_file = (
-                Path(QStandardPaths.writableLocation(QStandardPaths.TempLocation))
-                / "converted_sample.wav"
-            )
+            temp_file = tmp_dir / "converted_sample.wav"
             stream = ffmpeg.input(str(annotation.path))
             output = ffmpeg.output(
                 stream, str(temp_file), **{"ar": str(model.sampleRate())}

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -443,7 +443,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 / "converted_sample.wav"
             )
             stream = ffmpeg.input(str(annotation.path))
-            output = ffmpeg.output(stream, str(temp_file), **{"ar": str(model.sampleRate())})
+            output = ffmpeg.output(
+                stream, str(temp_file), **{"ar": str(model.sampleRate())}
+            )
             try:
                 ffmpeg.run(output)
             except FileNotFoundError:

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -430,7 +430,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 self,
                 self.tr("No model found"),
                 self.tr(
-                    "No language model specified. Choose a model under Edit>Select Language Model.."
+                    "No language model specified. Choose a model under Edit>Select Language Model... Pretrained models can be downloaded from <a href='https://coqui.ai/models'>https://coqui.ai/models</a>."
                 ),
             )
         model = Model(str(self.language_model))

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -254,8 +254,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     @Slot()
     def new_project(self):
-        if self.last_saved_hash != hash(self.project):
-
         self.project_file = None
         self.set_current_project(Project())
 

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -456,7 +456,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 )
             audio = wave.open(temp_file.open("rb"), "rb")
             audio = numpy.frombuffer(audio.readframes(audio.getnframes()), numpy.int16)
-            annotation.sentence = model.stt(audio)
+            annotation.sentence = model.stt(audio).capitalize() + "."
             temp_file.unlink()
         self.opened_project_frame.update_selected_annotation()
         return QMessageBox.information(

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -444,7 +444,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             )
             stream = ffmpeg.input(str(annotation.path))
             output = ffmpeg.output(stream, str(temp_file), **{"ar": str(model.sampleRate())})
-            ffmpeg.run(output)
+            try:
+                ffmpeg.run(output)
+            except FileNotFoundError:
+                return QMessageBox.warning(
+                    self,
+                    self.tr("No FFMPEG installation found"),
+                    self.tr(
+                        "No FFMPEG installation found. FFMPEG is required to process the audio files so they can be used by the speech to text module."
+                    ),
+                )
             audio = wave.open(temp_file.open("rb"), "rb")
             audio = numpy.frombuffer(audio.readframes(audio.getnframes()), numpy.int16)
             annotation.sentence = model.stt(audio)

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -451,9 +451,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             except FileNotFoundError:
                 return QMessageBox.warning(
                     self,
-                    self.tr("No FFMPEG installation found"),
+                    self.tr("No FFmpeg installation found"),
                     self.tr(
-                        "No FFMPEG installation found. FFMPEG is required to process the audio files so they can be used by the speech to text module."
+                        "No FFmpeg installation found. FFmpeg is required to process the audio files so they can be used by the speech to text module."
                     ),
                 )
             audio = wave.open(temp_file.open("rb"), "rb")

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -1,7 +1,10 @@
 from PySide6.QtCore import QModelIndex, Slot
 from PySide6.QtWidgets import QFrame, QFileDialog, QPushButton, QWidget
 
-from voice_annotation_tool.annotation_list_model import AnnotationListModel, ANNOTATION_ROLE
+from voice_annotation_tool.annotation_list_model import (
+    AnnotationListModel,
+    ANNOTATION_ROLE,
+)
 from voice_annotation_tool.opened_project_frame_ui import Ui_OpenedProjectFrame
 from voice_annotation_tool.project import Annotation, Project
 

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -174,6 +174,25 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
             annotations.append(selected_index.data(ANNOTATION_ROLE))
         return annotations
 
+    def update_selected_annotation(self):
+        """Update the GUI with the data of the selected sample."""
+        self.update_metadata_header()
+        index: QModelIndex = self.annotationList.currentIndex()
+        self.audioPlaybackWidget.previousButton.setEnabled(index.row() > 0)
+        self.audioPlaybackWidget.nextButton.setEnabled(
+            index.row() < len(self.project.annotations) - 1
+        )
+        annotation: Annotation = index.data(ANNOTATION_ROLE)
+        if not annotation:
+            return
+        self.annotationEdit.blockSignals(True)
+        self.annotationEdit.setText(annotation.sentence)
+        self.annotationEdit.blockSignals(False)
+        if annotation.path.is_file():
+            self.audioPlaybackWidget.load_file(annotation.path)
+        for buttons in self.get_playback_buttons():
+            buttons.setEnabled(annotation.path.is_file())
+
     @Slot()
     def previous_pressed(self):
         current = self.annotationList.currentIndex().row()
@@ -231,22 +250,7 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
 
     @Slot()
     def selection_changed(self, selected, deselected):
-        self.update_metadata_header()
-        index: QModelIndex = self.annotationList.currentIndex()
-        self.audioPlaybackWidget.previousButton.setEnabled(index.row() > 0)
-        self.audioPlaybackWidget.nextButton.setEnabled(
-            index.row() < len(self.project.annotations) - 1
-        )
-        annotation: Annotation = index.data(ANNOTATION_ROLE)
-        if not annotation:
-            return
-        self.annotationEdit.blockSignals(True)
-        self.annotationEdit.setText(annotation.sentence)
-        self.annotationEdit.blockSignals(False)
-        if annotation.path.is_file():
-            self.audioPlaybackWidget.load_file(annotation.path)
-        for buttons in self.get_playback_buttons():
-            buttons.setEnabled(annotation.path.is_file())
+        self.update_selected_annotation()
 
     @Slot()
     def import_profile_pressed(self):

--- a/src/voice_annotation_tool/project.py
+++ b/src/voice_annotation_tool/project.py
@@ -69,7 +69,7 @@ class Project:
             ]:
                 continue
             annotation = Annotation()
-            annotation.path = self.audio_folder.joinpath(path)
+            annotation.path = path
             self.add_annotation(annotation)
 
     def annotate(self, annotation: Annotation, text: str) -> None:
@@ -140,7 +140,7 @@ class Project:
 
         If the audio folder is specified, it is added to the annotation path.
         """
-        if self.audio_folder:
+        if self.audio_folder and self.audio_folder not in annotation.path.parents:
             annotation.path = self.audio_folder.joinpath(annotation.path)
         if annotation.path.name in self.annotations_by_path:
             if overwrite:

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -271,9 +271,9 @@
         <location filename="../src/voice_annotation_tool/main_window.py" line="216"/>
         <location filename="../src/voice_annotation_tool/main_window.py" line="228"/>
         <location filename="../src/voice_annotation_tool/main_window.py" line="251"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="293"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="315"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="378"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="291"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="313"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="376"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
@@ -323,100 +323,110 @@
         <translation>Der Pfad zur TSV-Datei ist invalide. Bitte ändere ihn in den Projekteinstellungen.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="265"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="263"/>
         <source>Open Project</source>
         <translation>Projekt Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="266"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="283"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="264"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="281"/>
         <source>Project Files (*.json)</source>
         <translation>Projektdateien (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="282"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="280"/>
         <source>Save Project</source>
         <translation>Projekt Speichern</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="294"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="292"/>
         <source>Delete the TSV and project file?</source>
         <translation>Die TSV und Projektdatei löschen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="317"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="315"/>
         <source>You have unsaved changes.</source>
         <translation>Es gibt ungespeicherte Änderungen.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="337"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="335"/>
         <source>Import CSV</source>
         <translation>CSV Importieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="338"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="348"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="336"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="346"/>
         <source>CSV Files (*.csv)</source>
         <translation>CSV Dateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="347"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="345"/>
         <source>Export CSV</source>
         <translation>CSV Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="357"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="355"/>
         <source>Import Json</source>
         <translation>Json Importieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="358"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="368"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="356"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="366"/>
         <source>Json Files (*.json)</source>
         <translation>Json Dateien (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="367"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="365"/>
         <source>Export Json</source>
         <translation>Json Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="379"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="377"/>
         <source>Really delete selected annotations and audio files?</source>
         <translation>Die ausgewählten Annotationen und Audiodateien wirklich löschen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="414"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="412"/>
         <source>https://voice-annotation-tool.readthedocs.io/en/latest/</source>
         <translation>https://voice-annotation-tool.readthedocs.io/en/latest/</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="420"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="418"/>
         <source>Open Language Model</source>
         <translation>Öffne Sprach-Modell</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="422"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="420"/>
         <source>TFLite Models (*.tflite)</source>
         <translation>TFLite Modelle (*.tflite)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="434"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="432"/>
         <source>No model found</source>
         <translation>Kein Modell gefunden</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="437"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="435"/>
         <source>No language model specified. Choose a model under Edit&gt;Select Language Model... Pretrained models can be downloaded from &lt;a href=&apos;https://coqui.ai/models&apos;&gt;https://coqui.ai/models&lt;/a&gt;.</source>
         <translation>Kein Sprachmodell festgelegt. Wähle ein Modell unter Editieren&gt;Wähle Sprachmodel Aus... Vortrainierte Modelle können von &lt;a href=&apos;https://coqui.ai/models&apos;&gt;https://coqui.ai/models&lt;/a&gt; heruntergeladen werden.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="471"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="454"/>
+        <source>No FFMPEG installation found</source>
+        <translation>Keine FFMPEG-Installation gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="457"/>
+        <source>No FFMPEG installation found. FFMPEG is required to process the audio files so they can be used by the speech to text module.</source>
+        <translation>Keine FFMPEG-Installation gefunden. FFMPEG wird benötigt, um die Audiodateien zu prozessieren, damit sie vom Sprach-zu-Text-Modul verwendet werden können.</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="466"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="474"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="469"/>
         <source>Samples without an annotated sentence have been automatically annotated.</source>
         <translation>Samples ohne annotierten Satz wurden automatisch annotiert.</translation>
     </message>
@@ -424,7 +434,7 @@
 <context>
     <name>OpenedProjectFrame</name>
     <message>
-        <location filename="../src/voice_annotation_tool/opened_project_frame.py" line="56"/>
+        <location filename="../src/voice_annotation_tool/opened_project_frame.py" line="59"/>
         <location filename="../ui/opened_project_frame.ui" line="77"/>
         <source>[Multiple]</source>
         <translation>[Mehrere]</translation>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -412,13 +412,13 @@
     </message>
     <message>
         <location filename="../src/voice_annotation_tool/main_window.py" line="454"/>
-        <source>No FFMPEG installation found</source>
-        <translation>Keine FFMPEG-Installation gefunden</translation>
+        <source>No FFmpeg installation found</source>
+        <translation>Keine FFmpeg-Installation gefunden</translation>
     </message>
     <message>
         <location filename="../src/voice_annotation_tool/main_window.py" line="457"/>
-        <source>No FFMPEG installation found. FFMPEG is required to process the audio files so they can be used by the speech to text module.</source>
-        <translation>Keine FFMPEG-Installation gefunden. FFMPEG wird benötigt, um die Audiodateien zu prozessieren, damit sie vom Sprach-zu-Text-Modul verwendet werden können.</translation>
+        <source>No FFmpeg installation found. FFmpeg is required to process the audio files so they can be used by the speech to text module.</source>
+        <translation>Keine FFmpeg-Installation gefunden. FFmpeg wird benötigt, um die Audiodateien zu prozessieren, damit sie vom Sprach-zu-Text-Modul verwendet werden können.</translation>
     </message>
     <message>
         <location filename="../src/voice_annotation_tool/main_window.py" line="466"/>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -90,7 +90,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/audio_playback_widget.py" line="78"/>
+        <location filename="../src/voice_annotation_tool/audio_playback_widget.py" line="81"/>
         <source>Error playing audio: {error}</source>
         <translation>Fehler beim abspielen: {error}</translation>
     </message>
@@ -131,260 +131,300 @@
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="63"/>
+        <location filename="../ui/main.ui" line="65"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="75"/>
+        <location filename="../ui/main.ui" line="77"/>
         <source>&amp;Open Project...</source>
         <translation>Projekt &amp;Öffnen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="78"/>
+        <location filename="../ui/main.ui" line="80"/>
         <source>Ctrl+O</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="83"/>
+        <location filename="../ui/main.ui" line="85"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="86"/>
+        <location filename="../ui/main.ui" line="88"/>
         <source>Ctrl+Q</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="94"/>
+        <location filename="../ui/main.ui" line="96"/>
         <source>&amp;Save Project</source>
         <translation>Projekt &amp;Speichern</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="97"/>
+        <location filename="../ui/main.ui" line="99"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="105"/>
+        <location filename="../ui/main.ui" line="107"/>
         <source>Save Project &amp;As...</source>
         <translation>Projekt Speichern &amp;Unter...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="108"/>
+        <location filename="../ui/main.ui" line="110"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="113"/>
+        <location filename="../ui/main.ui" line="115"/>
         <source>&amp;New Project...</source>
         <translation>&amp;Neues Projekt...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="116"/>
+        <location filename="../ui/main.ui" line="118"/>
         <source>Ctrl+N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="121"/>
+        <location filename="../ui/main.ui" line="123"/>
         <source>Configure &amp;Shortcuts...</source>
         <translation>Tastenkürzel &amp;Konfigurieren...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="145"/>
+        <location filename="../ui/main.ui" line="147"/>
         <source>Import CS&amp;V</source>
         <translation>CS&amp;V Importieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="153"/>
+        <location filename="../ui/main.ui" line="155"/>
         <source>Import Js&amp;on</source>
         <translation>Js&amp;on Importieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="161"/>
+        <location filename="../ui/main.ui" line="163"/>
         <source>Export &amp;CSV</source>
         <translation>&amp;CSV Exportieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="169"/>
+        <location filename="../ui/main.ui" line="171"/>
         <source>Export &amp;Json</source>
         <translation>&amp;Json Exportieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="177"/>
+        <location filename="../ui/main.ui" line="179"/>
         <source>&amp;Delete Project...</source>
         <translation>Projekt &amp;Löschen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="182"/>
+        <location filename="../ui/main.ui" line="187"/>
         <source>&amp;Delete Selected</source>
         <translation>Ausgewählte &amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="185"/>
+        <location filename="../ui/main.ui" line="190"/>
         <source>Delete the selected annotations including the audio files.</source>
         <translation>Die ausgewählten Annotationen und die dazugehörigen Audiodateien löschen.</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="188"/>
+        <location filename="../ui/main.ui" line="193"/>
         <source>Del</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="196"/>
+        <location filename="../ui/main.ui" line="201"/>
         <source>&amp;Project Settings</source>
         <translation>&amp;Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="201"/>
+        <location filename="../ui/main.ui" line="206"/>
         <source>Online &amp;Documentation</source>
         <translation>Online-&amp;Dokumentation</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="204"/>
+        <location filename="../ui/main.ui" line="209"/>
         <source>F1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="126"/>
+        <location filename="../ui/main.ui" line="220"/>
+        <source>&amp;Auto-Generate Annotation Text</source>
+        <translation>&amp;Auto-Generiere Annotations-Text</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="228"/>
+        <source>Select &amp;Language Model...</source>
+        <translation>&amp;Wähle Sprachmodel Aus...</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="128"/>
         <source>&amp;About</source>
         <translation>&amp;Über</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="134"/>
+        <location filename="../ui/main.ui" line="136"/>
         <source>About &amp;QT</source>
         <translation>Über &amp;QT</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="112"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="165"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="204"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="121"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="177"/>
         <location filename="../src/voice_annotation_tool/main_window.py" line="216"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="238"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="278"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="300"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="363"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="228"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="251"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="293"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="315"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="378"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="114"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="123"/>
         <source>Failed to parse the configuration file: {error}</source>
         <translation>Fehler beim Lesen der Konfigurationsdatei: {error}</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="149"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="161"/>
         <source>Unsaved Project</source>
         <translation>Ungespeichertes Projekt</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="168"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="180"/>
         <source>The audio folder or tsv file doesn&apos;t exist. Open project settings?</source>
         <translation>Der Audioordner oder die TSV-Datei existiert nicht. Projekteinstellungen öffnen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="177"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="189"/>
         <source>No samples found in the audio folder: {folder}</source>
         <translation>Keine Dateien im Audioordner gefunden: {folder}</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="191"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="203"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="192"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="204"/>
         <source>Invalid project.</source>
         <translation>Fehlerhaftes Projekt.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="203"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="215"/>
         <source>The TSV file doesn&apos;t exist. Please change it in the project settings</source>
         <translation>Die TSV-Datei existiert nicht. Bitte ändere sie in den Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="215"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="227"/>
         <source>The audio folder doesn&apos;t exist. Please change it in the project settings</source>
         <translation>Der Audio-Ordner existiert nicht. Bitte ändere ihn in den Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="237"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="250"/>
         <source>The TSV file path is invalid. Please change it in the project settings</source>
         <translation>Der Pfad zur TSV-Datei ist invalide. Bitte ändere ihn in den Projekteinstellungen.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="250"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="265"/>
         <source>Open Project</source>
         <translation>Projekt Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="251"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="268"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="266"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="283"/>
         <source>Project Files (*.json)</source>
         <translation>Projektdateien (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="267"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="282"/>
         <source>Save Project</source>
         <translation>Projekt Speichern</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="279"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="294"/>
         <source>Delete the TSV and project file?</source>
         <translation>Die TSV und Projektdatei löschen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="302"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="317"/>
         <source>You have unsaved changes.</source>
         <translation>Es gibt ungespeicherte Änderungen.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="322"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="337"/>
         <source>Import CSV</source>
         <translation>CSV Importieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="323"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="333"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="338"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="348"/>
         <source>CSV Files (*.csv)</source>
         <translation>CSV Dateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="332"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="347"/>
         <source>Export CSV</source>
         <translation>CSV Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="342"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="357"/>
         <source>Import Json</source>
         <translation>Json Importieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="343"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="353"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="358"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="368"/>
         <source>Json Files (*.json)</source>
         <translation>Json Dateien (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="352"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="367"/>
         <source>Export Json</source>
         <translation>Json Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="364"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="379"/>
         <source>Really delete selected annotations and audio files?</source>
         <translation>Die ausgewählten Annotationen und Audiodateien wirklich löschen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="397"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="414"/>
         <source>https://voice-annotation-tool.readthedocs.io/en/latest/</source>
         <translation>https://voice-annotation-tool.readthedocs.io/en/latest/</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="420"/>
+        <source>Open Language Model</source>
+        <translation>Öffne Sprach-Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="422"/>
+        <source>TFLite Models (*.tflite)</source>
+        <translation>TFLite Modelle (*.tflite)</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="434"/>
+        <source>No model found</source>
+        <translation>Kein Modell gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="437"/>
+        <source>No language model specified. Choose a model under Edit&gt;Select Language Model... Pretrained models can be downloaded from &lt;a href=&apos;https://coqui.ai/models&apos;&gt;https://coqui.ai/models&lt;/a&gt;.</source>
+        <translation>Kein Sprachmodell festgelegt. Wähle ein Modell unter Editieren&gt;Wähle Sprachmodel Aus... Vortrainierte Modelle können von &lt;a href=&apos;https://coqui.ai/models&apos;&gt;https://coqui.ai/models&lt;/a&gt; heruntergeladen werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="471"/>
+        <source>Done</source>
+        <translation>Fertig</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="474"/>
+        <source>Samples without an annotated sentence have been automatically annotated.</source>
+        <translation>Samples ohne annotierten Satz wurden automatisch annotiert.</translation>
     </message>
 </context>
 <context>
     <name>OpenedProjectFrame</name>
     <message>
-        <location filename="../src/voice_annotation_tool/opened_project_frame.py" line="61"/>
+        <location filename="../src/voice_annotation_tool/opened_project_frame.py" line="56"/>
         <location filename="../ui/opened_project_frame.ui" line="77"/>
         <source>[Multiple]</source>
         <translation>[Mehrere]</translation>

--- a/ui/main.ui
+++ b/ui/main.ui
@@ -51,12 +51,14 @@
      <string>&amp;Edit</string>
     </property>
     <addaction name="actionConfigureShortcuts"/>
+    <addaction name="actionSelectLanguageModel"/>
     <addaction name="actionProjectSettings"/>
     <addaction name="actionExportCSV"/>
     <addaction name="actionImportCSV"/>
     <addaction name="actionExportJson"/>
     <addaction name="actionImportJson"/>
     <addaction name="actionDeleteSelected"/>
+    <addaction name="actionAutoGenerate"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -205,6 +207,25 @@
    </property>
    <property name="shortcut">
     <string>F1</string>
+   </property>
+  </action>
+  <action name="actionAutoGenerate">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Auto-Generate Annotation Text</string>
+   </property>
+  </action>
+  <action name="actionSelectLanguageModel">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Select &amp;Language Model...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
When an audio file doesn't have the right extension or sample format, it is converted using ffmpeg and saved alongside the original file.

Todo:
- [x] Translations
- [x] Delete the temporary files afterwards
- [x] Documentation
- [x] Better sentence capitalization

**Future work:**

* Look into testing

Fixes #71 