### PR TITLE
Add a button to record new samples

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,3 +14,4 @@ Contents
    tsv_format
    import_export
    api
+   recording

--- a/docs/recording.rst
+++ b/docs/recording.rst
@@ -1,0 +1,6 @@
+Recording New Samples
+=====================
+
+New samples can be recorded directly from the application.
+
+Select the audio device you want to use and then press the `Record` button.

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -313,7 +313,7 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         if not self.project.audio_folder or not self.project.audio_folder.is_dir():
             return
         if self.recorder.recorderState() == QMediaRecorder.StoppedState:
-            name = "000" + "".join(random.choices(string.hexdigits, k=125))
+            name = "000" + "".join(random.choices("0123456789abcdef", k=125))
             path = QUrl.fromLocalFile(os.fspath(self.project.audio_folder / name))
             self.recorder.setOutputLocation(path)
             self.recorder.record()

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -313,9 +313,7 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         if not self.project.audio_folder or not self.project.audio_folder.is_dir():
             return
         if self.recorder.recorderState() == QMediaRecorder.StoppedState:
-            name = "".join(
-                random.choices(string.ascii_lowercase + string.digits * 2, k=129)
-            )
+            name = "".join(random.choices(string.hexdigits, k=129))
             path = QUrl.fromLocalFile(os.fspath(self.project.audio_folder / name))
             self.recorder.setOutputLocation(path)
             self.recorder.record()

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -189,7 +189,7 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         """Delete the selected annotations and audio files."""
         for selected in self.get_selected_annotations():
             self.project.delete_annotation(selected)
-        self.annotationList.model().layoutChanged.emit()
+        self.update_sample_list()
         self.update_metadata_widgets()
 
     def get_selected_annotations(self) -> list[Annotation]:
@@ -198,6 +198,11 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         for selected_index in self.annotationList.selectionModel().selectedIndexes():
             annotations.append(selected_index.data(ANNOTATION_ROLE))
         return annotations
+
+    def update_sample_list(self):
+        """Update the graphical representation of the
+        AnnotationListModel after it changed."""
+        self.annotationList.model().layoutChanged.emit()
 
     @Slot()
     def previous_pressed(self):
@@ -314,3 +319,5 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         else:
             self.recorder.stop()
             self.recordButton.setText(self.tr("Record Sample"))
+            self.project.load_audio_files(self.project.audio_folder)
+            self.update_sample_list()

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -313,7 +313,7 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         if not self.project.audio_folder or not self.project.audio_folder.is_dir():
             return
         if self.recorder.recorderState() == QMediaRecorder.StoppedState:
-            name = "".join(random.choices(string.hexdigits, k=129))
+            name = "000" + "".join(random.choices(string.hexdigits, k=125))
             path = QUrl.fromLocalFile(os.fspath(self.project.audio_folder / name))
             self.recorder.setOutputLocation(path)
             self.recorder.record()

--- a/src/voice_annotation_tool/opened_project_frame.py
+++ b/src/voice_annotation_tool/opened_project_frame.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import QModelIndex, QUrl, Slot
 from PySide6.QtMultimedia import (
     QAudioInput,
     QMediaCaptureSession,
+    QMediaDevices,
     QMediaFormat,
     QMediaRecorder,
 )
@@ -79,6 +80,9 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
         self.recorder.setAudioSampleRate(16000)
         self.recorder.setAudioBitRate(32)
         self.recorder.setQuality(QMediaRecorder.HighQuality)
+
+        for device in QMediaDevices.audioInputs():
+            self.deviceComboBox.addItem(device.description())
 
     def get_playback_buttons(self) -> list[QPushButton]:
         """Returns a list of buttons used to control the audio playback."""
@@ -321,3 +325,7 @@ class OpenedProjectFrame(QFrame, Ui_OpenedProjectFrame):
             self.recordButton.setText(self.tr("Record Sample"))
             self.project.load_audio_files(self.project.audio_folder)
             self.update_sample_list()
+
+    @Slot()
+    def device_selected(self, device: int):
+        self.input.setDevice(QMediaDevices.audioInputs()[device])

--- a/ui/opened_project_frame.ui
+++ b/ui/opened_project_frame.ui
@@ -199,6 +199,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QComboBox" name="deviceComboBox">
+       <property name="toolTip">
+        <string>Select the audio capture device used for recording.</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -344,12 +351,28 @@
    <slot>record_pressed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>819</x>
-     <y>709</y>
+     <x>978</x>
+     <y>689</y>
     </hint>
     <hint type="destinationlabel">
      <x>1234</x>
      <y>392</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>deviceComboBox</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>OpenedProjectFrame</receiver>
+   <slot>device_selected(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>823</x>
+     <y>707</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1233</x>
+     <y>637</y>
     </hint>
    </hints>
   </connection>
@@ -369,5 +392,6 @@
   <slot>mark_unchanged_pressed()</slot>
   <slot>metadata_changed(QString)</slot>
   <slot>record_pressed()</slot>
+  <slot>device_selected(int)</slot>
  </slots>
 </ui>

--- a/ui/opened_project_frame.ui
+++ b/ui/opened_project_frame.ui
@@ -189,6 +189,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="recordButton">
+       <property name="toolTip">
+        <string>Start recording a new sample and save it to the audio folder selected in the project settings. Click the button again to stop recording.</string>
+       </property>
+       <property name="text">
+        <string>&amp;Record Sample</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -270,8 +280,8 @@
    <slot>gender_selected(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>542</x>
-     <y>34</y>
+     <x>540</x>
+     <y>43</y>
     </hint>
     <hint type="destinationlabel">
      <x>1062</x>
@@ -286,8 +296,8 @@
    <slot>accent_changed(QString)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>542</x>
-     <y>86</y>
+     <x>540</x>
+     <y>90</y>
     </hint>
     <hint type="destinationlabel">
      <x>1047</x>
@@ -327,6 +337,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>recordButton</sender>
+   <signal>pressed()</signal>
+   <receiver>OpenedProjectFrame</receiver>
+   <slot>record_pressed()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>819</x>
+     <y>709</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1234</x>
+     <y>392</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>previous_pressed()</slot>
@@ -342,5 +368,6 @@
   <slot>play_pause_pressed()</slot>
   <slot>mark_unchanged_pressed()</slot>
   <slot>metadata_changed(QString)</slot>
+  <slot>record_pressed()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
Fixes #72 

**Todo:**

- [x] Update sample list after recording
- [x] Ability to choose capture device
- [x] Decide on a naming scheme
- [x] Documentation
- [ ] Test on Windows

**Future work:**
* Recognize devices connected on runtime
* Translations