### PR TITLE
Edit Menu cleanup

### DIFF
--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -346,7 +346,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     @Slot()
     def close_project(self):
-        self.return_to_start_screen()
+        if self.confirm_discard_unsaved_changes():
+            self.return_to_start_screen()
 
     @Slot()
     def quit(self):

--- a/src/voice_annotation_tool/main_window.py
+++ b/src/voice_annotation_tool/main_window.py
@@ -258,8 +258,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         last saved, and if there have, ask if they want to
         save or discard them.
 
-        Returns true if the user wants to discard unsaved
-        changes or if there are none.
+        Returns true if the user is ok with the status of
+        the project, false if they canceled the operation.
         """
         if hash(self.project) == self.last_saved_hash:
             return True
@@ -285,7 +285,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def return_to_start_screen(self):
         """Close the current project and set up the UI as
-        it where before opening a project.
+        it was before opening a project.
         """
         self.last_saved_hash = 0
         self.project_file = None

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -90,7 +90,7 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/audio_playback_widget.py" line="78"/>
+        <location filename="../src/voice_annotation_tool/audio_playback_widget.py" line="81"/>
         <source>Error playing audio: {error}</source>
         <translation>Fehler beim abspielen: {error}</translation>
     </message>
@@ -121,262 +121,296 @@
         <translation>Stimmenannotations-Werkzeug</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="40"/>
         <source>&amp;File</source>
-        <translation>&amp;Datei</translation>
+        <translation type="vanished">&amp;Datei</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="51"/>
+        <location filename="../ui/main.ui" line="53"/>
         <source>&amp;Edit</source>
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="63"/>
+        <location filename="../ui/main.ui" line="65"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="75"/>
         <source>&amp;Open Project...</source>
-        <translation>Projekt &amp;Öffnen...</translation>
+        <translation type="vanished">Projekt &amp;Öffnen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="78"/>
+        <location filename="../ui/main.ui" line="80"/>
         <source>Ctrl+O</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="83"/>
+        <location filename="../ui/main.ui" line="85"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="86"/>
+        <location filename="../ui/main.ui" line="88"/>
         <source>Ctrl+Q</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="94"/>
         <source>&amp;Save Project</source>
-        <translation>Projekt &amp;Speichern</translation>
+        <translation type="vanished">Projekt &amp;Speichern</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="97"/>
+        <location filename="../ui/main.ui" line="99"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="105"/>
         <source>Save Project &amp;As...</source>
-        <translation>Projekt Speichern &amp;Unter...</translation>
+        <translation type="vanished">Projekt Speichern &amp;Unter...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="108"/>
+        <location filename="../ui/main.ui" line="110"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="113"/>
         <source>&amp;New Project...</source>
-        <translation>&amp;Neues Projekt...</translation>
+        <translation type="vanished">&amp;Neues Projekt...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="116"/>
+        <location filename="../ui/main.ui" line="118"/>
         <source>Ctrl+N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="121"/>
+        <location filename="../ui/main.ui" line="123"/>
         <source>Configure &amp;Shortcuts...</source>
         <translation>Tastenkürzel &amp;Konfigurieren...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="145"/>
+        <location filename="../ui/main.ui" line="147"/>
         <source>Import CS&amp;V</source>
         <translation>CS&amp;V Importieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="153"/>
+        <location filename="../ui/main.ui" line="155"/>
         <source>Import Js&amp;on</source>
         <translation>Js&amp;on Importieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="161"/>
+        <location filename="../ui/main.ui" line="163"/>
         <source>Export &amp;CSV</source>
         <translation>&amp;CSV Exportieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="169"/>
+        <location filename="../ui/main.ui" line="171"/>
         <source>Export &amp;Json</source>
         <translation>&amp;Json Exportieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="177"/>
         <source>&amp;Delete Project...</source>
-        <translation>Projekt &amp;Löschen...</translation>
+        <translation type="vanished">Projekt &amp;Löschen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="182"/>
+        <location filename="../ui/main.ui" line="187"/>
         <source>&amp;Delete Selected</source>
         <translation>Ausgewählte &amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="185"/>
+        <location filename="../ui/main.ui" line="190"/>
         <source>Delete the selected annotations including the audio files.</source>
         <translation>Die ausgewählten Annotationen und die dazugehörigen Audiodateien löschen.</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="188"/>
+        <location filename="../ui/main.ui" line="193"/>
         <source>Del</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="196"/>
+        <location filename="../ui/main.ui" line="201"/>
         <source>&amp;Project Settings</source>
         <translation>&amp;Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="201"/>
+        <location filename="../ui/main.ui" line="206"/>
         <source>Online &amp;Documentation</source>
         <translation>Online-&amp;Dokumentation</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="204"/>
+        <location filename="../ui/main.ui" line="209"/>
         <source>F1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="126"/>
+        <location filename="../ui/main.ui" line="128"/>
         <source>&amp;About</source>
         <translation>&amp;Über</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="134"/>
+        <location filename="../ui/main.ui" line="40"/>
+        <source>&amp;Project</source>
+        <translation>&amp;Projekt</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="77"/>
+        <source>&amp;Open...</source>
+        <translation>&amp;Öffnen...</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="96"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Speichern</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="107"/>
+        <source>Save &amp;As...</source>
+        <translation>Speichern &amp;Unter...</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="115"/>
+        <source>&amp;New...</source>
+        <translation>&amp;Neu...</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="136"/>
         <source>About &amp;QT</source>
         <translation>Über &amp;QT</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="112"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="165"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="204"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="216"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="238"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="278"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="300"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="363"/>
+        <location filename="../ui/main.ui" line="179"/>
+        <source>&amp;Delete...</source>
+        <translation>&amp;Löschen...</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="217"/>
+        <source>Close</source>
+        <translation>Schließen</translation>
+    </message>
+    <message>
+        <location filename="../ui/main.ui" line="220"/>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
+    </message>
+    <message>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="110"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="158"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="199"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="211"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="234"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="250"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="317"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="386"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="114"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="112"/>
         <source>Failed to parse the configuration file: {error}</source>
         <translation>Fehler beim Lesen der Konfigurationsdatei: {error}</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="149"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="142"/>
         <source>Unsaved Project</source>
         <translation>Ungespeichertes Projekt</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="168"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="161"/>
         <source>The audio folder or tsv file doesn&apos;t exist. Open project settings?</source>
         <translation>Der Audioordner oder die TSV-Datei existiert nicht. Projekteinstellungen öffnen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="177"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="170"/>
         <source>No samples found in the audio folder: {folder}</source>
         <translation>Keine Dateien im Audioordner gefunden: {folder}</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="191"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="186"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="192"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="187"/>
         <source>Invalid project.</source>
         <translation>Fehlerhaftes Projekt.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="203"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="198"/>
         <source>The TSV file doesn&apos;t exist. Please change it in the project settings</source>
         <translation>Die TSV-Datei existiert nicht. Bitte ändere sie in den Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="215"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="210"/>
         <source>The audio folder doesn&apos;t exist. Please change it in the project settings</source>
         <translation>Der Audio-Ordner existiert nicht. Bitte ändere ihn in den Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="237"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="233"/>
         <source>The TSV file path is invalid. Please change it in the project settings</source>
         <translation>Der Pfad zur TSV-Datei ist invalide. Bitte ändere ihn in den Projekteinstellungen.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="250"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="289"/>
         <source>Open Project</source>
         <translation>Projekt Öffnen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="251"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="268"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="290"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="307"/>
         <source>Project Files (*.json)</source>
         <translation>Projektdateien (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="267"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="306"/>
         <source>Save Project</source>
         <translation>Projekt Speichern</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="279"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="318"/>
         <source>Delete the TSV and project file?</source>
         <translation>Die TSV und Projektdatei löschen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="302"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="252"/>
         <source>You have unsaved changes.</source>
         <translation>Es gibt ungespeicherte Änderungen.</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="322"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="345"/>
         <source>Import CSV</source>
         <translation>CSV Importieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="323"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="333"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="346"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="356"/>
         <source>CSV Files (*.csv)</source>
         <translation>CSV Dateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="332"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="355"/>
         <source>Export CSV</source>
         <translation>CSV Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="342"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="365"/>
         <source>Import Json</source>
         <translation>Json Importieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="343"/>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="353"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="366"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="376"/>
         <source>Json Files (*.json)</source>
         <translation>Json Dateien (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="352"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="375"/>
         <source>Export Json</source>
         <translation>Json Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="364"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="387"/>
         <source>Really delete selected annotations and audio files?</source>
         <translation>Die ausgewählten Annotationen und Audiodateien wirklich löschen?</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/main_window.py" line="397"/>
+        <location filename="../src/voice_annotation_tool/main_window.py" line="431"/>
         <source>https://voice-annotation-tool.readthedocs.io/en/latest/</source>
         <translation>https://voice-annotation-tool.readthedocs.io/en/latest/</translation>
     </message>
@@ -384,7 +418,7 @@
 <context>
     <name>OpenedProjectFrame</name>
     <message>
-        <location filename="../src/voice_annotation_tool/opened_project_frame.py" line="61"/>
+        <location filename="../src/voice_annotation_tool/opened_project_frame.py" line="56"/>
         <location filename="../ui/opened_project_frame.ui" line="77"/>
         <source>[Multiple]</source>
         <translation>[Mehrere]</translation>
@@ -491,9 +525,22 @@
         <translation>Tastenkürzel-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/voice_annotation_tool/shortcut_settings_dialog.py" line="69"/>
+        <location filename="../src/voice_annotation_tool/shortcut_settings_dialog.py" line="57"/>
         <source>{shortcut} is already used elsewhere in the application.</source>
         <translation>{shortcut} wird bereits anderswo verwendet.</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutWidget</name>
+    <message>
+        <location filename="../ui/shortcut_widget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcut_widget.ui" line="42"/>
+        <source>Click and press any key to change the shortcut. Right click to reset.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -127,6 +127,7 @@
         <translation>&amp;Datei</translation>
     </message>
     <message>
+        <location filename="../ui/main.ui" line="235"/>
         <location filename="../ui/main_master.ui" line="220"/>
         <source>&amp;Auto-Generate Annotation Text</source>
         <translation>&amp;Auto-Generiere Annotations-Text</translation>
@@ -138,7 +139,7 @@
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="66"/>
+        <location filename="../ui/main.ui" line="67"/>
         <location filename="../ui/main_master.ui" line="65"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
@@ -149,19 +150,19 @@
         <translation>Projekt &amp;Öffnen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="81"/>
+        <location filename="../ui/main.ui" line="82"/>
         <location filename="../ui/main_master.ui" line="80"/>
         <source>Ctrl+O</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="86"/>
+        <location filename="../ui/main.ui" line="87"/>
         <location filename="../ui/main_master.ui" line="85"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="89"/>
+        <location filename="../ui/main.ui" line="90"/>
         <location filename="../ui/main_master.ui" line="88"/>
         <source>Ctrl+Q</source>
         <translation></translation>
@@ -172,7 +173,7 @@
         <translation>Projekt &amp;Speichern</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="100"/>
+        <location filename="../ui/main.ui" line="101"/>
         <location filename="../ui/main_master.ui" line="99"/>
         <source>Ctrl+S</source>
         <translation></translation>
@@ -183,7 +184,7 @@
         <translation>Projekt Speichern &amp;Unter...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="111"/>
+        <location filename="../ui/main.ui" line="112"/>
         <location filename="../ui/main_master.ui" line="110"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
@@ -194,37 +195,37 @@
         <translation>&amp;Neues Projekt...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="119"/>
+        <location filename="../ui/main.ui" line="120"/>
         <location filename="../ui/main_master.ui" line="118"/>
         <source>Ctrl+N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="124"/>
+        <location filename="../ui/main.ui" line="125"/>
         <location filename="../ui/main_master.ui" line="123"/>
         <source>Configure &amp;Shortcuts...</source>
         <translation>Tastenkürzel &amp;Konfigurieren...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="148"/>
+        <location filename="../ui/main.ui" line="149"/>
         <location filename="../ui/main_master.ui" line="147"/>
         <source>Import CS&amp;V</source>
         <translation>CS&amp;V Importieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="156"/>
+        <location filename="../ui/main.ui" line="157"/>
         <location filename="../ui/main_master.ui" line="155"/>
         <source>Import Js&amp;on</source>
         <translation>Js&amp;on Importieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="164"/>
+        <location filename="../ui/main.ui" line="165"/>
         <location filename="../ui/main_master.ui" line="163"/>
         <source>Export &amp;CSV</source>
         <translation>&amp;CSV Exportieren</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="172"/>
+        <location filename="../ui/main.ui" line="173"/>
         <location filename="../ui/main_master.ui" line="171"/>
         <source>Export &amp;Json</source>
         <translation>&amp;Json Exportieren</translation>
@@ -235,43 +236,43 @@
         <translation>Projekt &amp;Löschen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="188"/>
+        <location filename="../ui/main.ui" line="189"/>
         <location filename="../ui/main_master.ui" line="187"/>
         <source>&amp;Delete Selected</source>
         <translation>Ausgewählte &amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="191"/>
+        <location filename="../ui/main.ui" line="192"/>
         <location filename="../ui/main_master.ui" line="190"/>
         <source>Delete the selected annotations including the audio files.</source>
         <translation>Die ausgewählten Annotationen und die dazugehörigen Audiodateien löschen.</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="194"/>
+        <location filename="../ui/main.ui" line="195"/>
         <location filename="../ui/main_master.ui" line="193"/>
         <source>Del</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="202"/>
+        <location filename="../ui/main.ui" line="203"/>
         <location filename="../ui/main_master.ui" line="201"/>
         <source>&amp;Project Settings</source>
         <translation>&amp;Projekteinstellungen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="207"/>
+        <location filename="../ui/main.ui" line="208"/>
         <location filename="../ui/main_master.ui" line="206"/>
         <source>Online &amp;Documentation</source>
         <translation>Online-&amp;Dokumentation</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="210"/>
+        <location filename="../ui/main.ui" line="211"/>
         <location filename="../ui/main_master.ui" line="209"/>
         <source>F1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="129"/>
+        <location filename="../ui/main.ui" line="130"/>
         <location filename="../ui/main_master.ui" line="128"/>
         <source>&amp;About</source>
         <translation>&amp;Über</translation>
@@ -282,48 +283,48 @@
         <translation>&amp;Projekt</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="78"/>
+        <location filename="../ui/main.ui" line="79"/>
         <source>&amp;Open...</source>
         <translation>&amp;Öffnen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="97"/>
+        <location filename="../ui/main.ui" line="98"/>
         <source>&amp;Save</source>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="108"/>
+        <location filename="../ui/main.ui" line="109"/>
         <source>Save &amp;As...</source>
         <translation>Speichern &amp;Unter...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="116"/>
+        <location filename="../ui/main.ui" line="117"/>
         <source>&amp;New...</source>
         <translation>&amp;Neu...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="137"/>
+        <location filename="../ui/main.ui" line="138"/>
         <location filename="../ui/main_master.ui" line="136"/>
         <source>About &amp;QT</source>
         <translation>Über &amp;QT</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="180"/>
+        <location filename="../ui/main.ui" line="181"/>
         <source>&amp;Delete...</source>
         <translation>&amp;Löschen...</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="218"/>
+        <location filename="../ui/main.ui" line="219"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="221"/>
+        <location filename="../ui/main.ui" line="222"/>
         <source>Ctrl+W</source>
         <translation>Ctrl+W</translation>
     </message>
     <message>
-        <location filename="../ui/main.ui" line="226"/>
+        <location filename="../ui/main.ui" line="227"/>
         <location filename="../ui/main_master.ui" line="228"/>
         <source>Select &amp;Language Model...</source>
         <translation>&amp;Wähle Sprachmodel Aus...</translation>

--- a/ui/main.ui
+++ b/ui/main.ui
@@ -37,14 +37,16 @@
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
-     <string>&amp;File</string>
+     <string>&amp;Project</string>
     </property>
     <addaction name="actionNewProject"/>
     <addaction name="actionOpen"/>
     <addaction name="actionSaveProject"/>
     <addaction name="actionSaveProjectAs"/>
     <addaction name="actionDeleteProject"/>
+    <addaction name="actionCloseProject"/>
     <addaction name="actionQuit"/>
+    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">
@@ -72,7 +74,7 @@
   </widget>
   <action name="actionOpen">
    <property name="text">
-    <string>&amp;Open Project...</string>
+    <string>&amp;Open...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -91,7 +93,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>&amp;Save Project</string>
+    <string>&amp;Save</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
@@ -102,7 +104,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Save Project &amp;As...</string>
+    <string>Save &amp;As...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
@@ -110,7 +112,7 @@
   </action>
   <action name="actionNewProject">
    <property name="text">
-    <string>&amp;New Project...</string>
+    <string>&amp;New...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+N</string>
@@ -174,7 +176,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>&amp;Delete Project...</string>
+    <string>&amp;Delete...</string>
    </property>
   </action>
   <action name="actionDeleteSelected">
@@ -205,6 +207,17 @@
    </property>
    <property name="shortcut">
     <string>F1</string>
+   </property>
+  </action>
+  <action name="actionCloseProject">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Close</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+W</string>
    </property>
   </action>
  </widget>

--- a/ui/main.ui
+++ b/ui/main.ui
@@ -60,6 +60,7 @@
     <addaction name="actionExportJson"/>
     <addaction name="actionImportJson"/>
     <addaction name="actionDeleteSelected"/>
+    <addaction name="actionAutoGenerate"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -224,6 +225,14 @@
   <action name="actionSelectLanguageModel">
    <property name="text">
     <string>Select &amp;Language Model...</string>
+   </property>
+  </action>
+  <action name="actionAutoGenerate">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Auto-Generate Annotation Text</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Rename the Edit menu to Project, and remove "Project" from all options.

Add an option to close the current project, and ask the user if he wants to discard unsaved changes on more actions. 

Closes #74 